### PR TITLE
Update optparse to argparse

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,13 @@ cwd = os.path.abspath(os.path.dirname(__file__))
 
 setup(
     name='objtree',
-    version='0.5.2',
+    version='0.5.3',
     description="tree but for Objective-C messages",
     author='hot3eed',
     author_email='hot3eed@gmail.com',
     url='https://github.com/hot3eed/objtree',
     install_requires=[
-        'frida-tools >= 9.0.0, < 10.0.0',
+        'frida-tools',
     ],
     license='Apache License 2.0',
     keywords='dynamic-instrumentation ios macos frida debugger',


### PR DESCRIPTION
The required version of Frida is too old and have some big bugs (as an example, I couldn't even attach anything to my USB device). It was using optparse which is now deprecated (for a while) and was giving the following error when launching because Frida now uses Argparse instead of optparse:
```
Traceback (most recent call last):
  File "/opt/homebrew/bin/objtree", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/objtree/cli.py", line 99, in main
    app = TestApplication()
          ^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/frida_tools/application.py", line 152, in __init__
    parser = self._initialize_arguments_parser()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/frida_tools/application.py", line 257, in _initialize_arguments_parser
    self._add_options(parser)
  File "/opt/homebrew/lib/python3.11/site-packages/objtree/cli.py", line 17, in _add_options
    parser.add_option('-m', help="include OBJC_METHOD",
    ^^^^^^^^^^^^^^^^^
AttributeError: 'ArgumentParser' object has no attribute 'add_option'. Did you mean: '_add_action'?
```
I fixed this issue by changing to argparse, and now we can use latest frida-tools version.